### PR TITLE
Screen wasn't unlocking due to the orientation being forced to whatev…

### DIFF
--- a/src/ios/YoikScreenOrientation.m
+++ b/src/ios/YoikScreenOrientation.m
@@ -52,9 +52,6 @@
                 break;
         }
         
-        if ([orientationIn isEqual: @"unlocked"]) {
-            orientationIn = orientation;
-        }
         // we send the result prior to the view controller presentation so that the JS side
         // is ready for the unlock call.
         CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK


### PR DESCRIPTION
…er the device was set to, regardless of the fact you want it to be free.

Locking the device was fine. Unlocking however wasn't working. This small fix solves that.
